### PR TITLE
Cache: use job name without branch

### DIFF
--- a/vars/restoreCache.groovy
+++ b/vars/restoreCache.groovy
@@ -1,9 +1,10 @@
 #!/usr/bin/groovy
 
 def call(String file) {
+    def jobName = env.JOB_NAME.split('/')[0]
     try {
         sh """
-        cache_dir="\$HOME/cache/${URLDecoder.decode(JOB_NAME)}"
+        cache_dir="\$HOME/cache/${jobName}"
         mkdir -p \$cache_dir
         cache_file=\"\$cache_dir/\$( sha1sum ${file} |awk '{ print \$1 }' ).tar.gz\"
         if [ -f "\$cache_file" ]; then

--- a/vars/saveCache.groovy
+++ b/vars/saveCache.groovy
@@ -1,6 +1,7 @@
 #!/usr/bin/groovy
 
 def call(String cache_file, String directory, Integer clean_old = 0, String exclude="") {
+    def jobName = env.JOB_NAME.split('/')[0]
     try {
         if (exclude.length() > 0) {
             sh """
@@ -23,7 +24,7 @@ def call(String cache_file, String directory, Integer clean_old = 0, String excl
             """            
         }
         if (clean_old > 0){
-            sh "find $HOME/cache/${URLDecoder.decode(JOB_NAME)} -name '*.tar.gz' -ctime +${clean_old} -delete"
+            sh "find $HOME/cache/${jobName} -name '*.tar.gz' -ctime +${clean_old} -delete"
         }
     } catch (err) {
         echo "Error: ${err}"

--- a/workflows/devnet-build/Jenkinsfile
+++ b/workflows/devnet-build/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline{
     stages {
         stage('Load library') {
             steps {
-                library 'lisk-jenkins'
+                library 'lisk-jenkins@per_job_cache'
             }
         }
         stage('Build release') {


### PR DESCRIPTION
Split the path so every cached file is shared across branches.