### PR TITLE
Add function to cancel previous running build

### DIFF
--- a/vars/cancelPreviousBuild.groovy
+++ b/vars/cancelPreviousBuild.groovy
@@ -1,0 +1,7 @@
+#!/usr/bin/groovy
+
+def call() {
+    def prevBuild = currentBuild.previousBuild
+    if (prevBuild)
+        prevBuild.rawBuild._this().doTerm();
+}


### PR DESCRIPTION
If we have more then one node / executor available, this function allows to cancel the previous running build so only the last one takes resources.